### PR TITLE
Add mapping config for topic to table names

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -36,6 +36,7 @@ public class SinkPropertiesFactory {
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, "kcbq-test");
     properties.put(BigQuerySinkConfig.PROJECT_CONFIG, "test-project");
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=test");
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, "kcbq-test=kcbq-test-table");
 
     properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, "key.json");
 
@@ -56,8 +57,10 @@ public class SinkPropertiesFactory {
     config.getTopicsToDatasets();
 
     config.getMap(config.DATASETS_CONFIG);
+    config.getMap(config.TOPICS_TO_TABLES_CONFIG);
 
     config.getList(config.TOPICS_CONFIG);
+    config.getList(config.TOPICS_TO_TABLES_CONFIG);
     config.getList(config.DATASETS_CONFIG);
 
     config.getString(config.KEYFILE_CONFIG);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -102,6 +102,33 @@ public class BigQuerySinkConfigTest {
   }
 
   @Test
+  public void testTopicsToTables() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_CONFIG,
+        "sanitize-me,leave_me_alone"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "leave_me_alone=leaveMeAlone"
+    );
+    Map<TableId, String> expectedTablesToSchemas = new HashMap<>();
+    expectedTablesToSchemas.put(TableId.of("scratch", "sanitize_me"), "sanitize-me");
+    expectedTablesToSchemas.put(TableId.of("scratch", "leaveMeAlone"), "leave_me_alone");
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    Map<String, String> topicsToDatasets = testConfig.getTopicsToDatasets();
+    Map<TableId, String> testTablesToSchemas = testConfig.getTablesToTopics(topicsToDatasets);
+
+    assertEquals(expectedTablesToSchemas, testTablesToSchemas);
+  }
+
+  @Test
   public void testGetSchemaConverter() {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.INCLUDE_KAFKA_DATA_CONFIG, "true");


### PR DESCRIPTION
In cases where we do not want our table names to directly match our
topic names, provide a configuration to rename the topics.