### PR TITLE
Implement in-memory schema retriever

### DIFF
--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -25,4 +25,12 @@ public interface SchemaRetriever {
    * @return The Schema for the given table.
    */
   public Schema retrieveSchema(TableId table, String topic);
+
+  /**
+   * Set the last seen schema for a given topic
+   * @param table The table that will be created.
+   * @param topic The topic to retrieve a schema for.
+   * @param schema The last seen Kafka Connect Schema
+   */
+  public void setLastSeenSchema(TableId table, String topic, Schema schema);
 }

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -71,6 +71,9 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
     }
   }
 
+  @Override
+  public void setLastSeenSchema(TableId table, String topic, Schema schema) { }
+
   private String getSubject(String topic) {
     return topic + "-value";
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
@@ -1,0 +1,58 @@
+package com.wepay.kafka.connect.bigquery.retrieve;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.
+ */
+public class MemorySchemaRetriever implements SchemaRetriever {
+  private static final Logger logger = LoggerFactory.getLogger(MemorySchemaRetriever.class);
+  private static final int CACHE_SIZE = 1000;
+  private Cache<String, Schema> schemaCache;
+
+  /**
+   * Only here because the package-private constructor (which is only used in testing) would
+   * otherwise cover up the no-args constructor.
+   */
+  public MemorySchemaRetriever() {
+  }
+
+  private String getCacheKey(String tableName, String topic) {
+    return new StringBuilder(tableName).append(topic).toString();
+  }
+
+  @Override
+  public void configure(Map<String, String> properties) {
+    schemaCache = new SynchronizedCache<>(new LRUCache<String, Schema>(CACHE_SIZE));
+  }
+
+  @Override
+  public Schema retrieveSchema(TableId table, String topic) {
+    String tableName = table.getTable();
+    Schema schema = schemaCache.get(getCacheKey(tableName, topic));
+    if (schema != null) {
+      logger.info("Using cached schema");
+      return schema;
+    }
+
+    logger.info("Using empty struct");
+    return SchemaBuilder.struct().build();
+  }
+
+  @Override
+  public void setLastSeenSchema(TableId table, String topic, Schema schema) {
+    logger.info("Updating last seen schema to " + schema.toString());
+    schemaCache.put(getCacheKey(table.getTable(), topic), schema);
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
@@ -42,17 +42,15 @@ public class MemorySchemaRetriever implements SchemaRetriever {
     String tableName = table.getTable();
     Schema schema = schemaCache.get(getCacheKey(tableName, topic));
     if (schema != null) {
-      logger.info("Using cached schema");
       return schema;
     }
 
-    logger.info("Using empty struct");
     return SchemaBuilder.struct().build();
   }
 
   @Override
   public void setLastSeenSchema(TableId table, String topic, Schema schema) {
-    logger.info("Updating last seen schema to " + schema.toString());
+    logger.debug("Updating last seen schema to " + schema.toString());
     schemaCache.put(getCacheKey(table.getTable(), topic), schema);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -65,6 +65,10 @@ public class BigQuerySinkConnectorTest {
       // Shouldn't be called
       return null;
     }
+
+    @Override
+    public void setLastSeenSchema(TableId table, String topic, Schema schema) {
+    }
   }
 
   @BeforeClass

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
@@ -1,0 +1,74 @@
+package com.wepay.kafka.connect.bigquery.retrieve;
+
+
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+
+public class MemorySchemaRetrieverTest {
+    public TableId getTableId(String datasetName, String tableName) {
+        return TableId.of(datasetName, tableName);
+    }
+
+    @Test
+    public void testRetrieveSchemaWhenNoLastSeenSchemaReturnsEmptyStructSchema() {
+        final String topic = "test-retrieve";
+        final TableId tableId = getTableId("testTable", "testDataset");
+        SchemaRetriever retriever = new MemorySchemaRetriever();
+        retriever.configure(new HashMap<>());
+        Assert.assertEquals(retriever.retrieveSchema(tableId, topic), SchemaBuilder.struct().build());
+    }
+
+    @Test
+    public void testRetrieveSchemaWhenLastSeenExistsSucceeds() {
+        final String topic = "test-retrieve";
+        final TableId tableId = getTableId("testTable", "testDataset");
+        SchemaRetriever retriever = new MemorySchemaRetriever();
+        retriever.configure(new HashMap<>());
+
+        Schema expectedSchema = Schema.OPTIONAL_FLOAT32_SCHEMA;
+        retriever.setLastSeenSchema(tableId, topic, expectedSchema);
+
+        Assert.assertEquals(retriever.retrieveSchema(tableId, topic), expectedSchema);
+    }
+
+    @Test
+    public void testRetrieveSchemaWithMultipleSchemasSucceeds() {
+        final String floatSchemaTopic = "test-float32";
+        final String intSchemaTopic = "test-int32";
+        final TableId floatTableId = getTableId("testFloatTable", "testFloatDataset");
+        final TableId intTableId = getTableId("testIntTable", "testIntDataset");
+        SchemaRetriever retriever = new MemorySchemaRetriever();
+        retriever.configure(new HashMap<>());
+
+        Schema expectedIntSchema = Schema.INT32_SCHEMA;
+        Schema expectedFloatSchema = Schema.OPTIONAL_FLOAT32_SCHEMA;
+        retriever.setLastSeenSchema(floatTableId, floatSchemaTopic, expectedFloatSchema);
+        retriever.setLastSeenSchema(intTableId, intSchemaTopic, expectedIntSchema);
+
+        Assert.assertEquals(retriever.retrieveSchema(floatTableId, floatSchemaTopic), expectedFloatSchema);
+        Assert.assertEquals(retriever.retrieveSchema(intTableId, intSchemaTopic), expectedIntSchema);
+    }
+
+    @Test
+    public void testRetrieveSchemaRetrievesLastSeenSchema() {
+        final String intSchemaTopic = "test-int";
+        final TableId tableId = getTableId("testTable", "testDataset");
+        SchemaRetriever retriever = new MemorySchemaRetriever();
+        retriever.configure(new HashMap<>());
+
+        Schema firstSchema = Schema.INT32_SCHEMA;
+        Schema secondSchema = Schema.INT64_SCHEMA;
+        retriever.setLastSeenSchema(tableId, intSchemaTopic, firstSchema);
+        retriever.setLastSeenSchema(tableId, intSchemaTopic, secondSchema);
+
+        Assert.assertEquals(retriever.retrieveSchema(tableId, intSchemaTopic), secondSchema);
+    }
+}


### PR DESCRIPTION
This change implements an in-memory schema retriever. This allows us to use the table creation and schema update features with topics that don't use the schema registry

I tested this locally with topics that use the schema registry and with those that don't to verify